### PR TITLE
Revert "feat: Add UploadFromReader function to allow uploading from a…

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,7 +1,6 @@
 package bunnystorage
 
 import (
-	"bytes"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -48,29 +47,18 @@ func (c *Client) WithLogger(l resty.Logger) *Client {
 
 // Uploads a file to the relative path. generateChecksum controls if a checksum gets generated and attached to the upload request. Returns an error.
 func (c *Client) Upload(path string, content []byte, generateChecksum bool) error {
-	return c.UploadFromReader(path, bytes.NewReader(content), generateChecksum)
-}
-
-// Uploads a file to the relative path. generateChecksum controls if a checksum gets generated and attached to the upload request. Returns an error. Allows passing a reader instead of a []byte
-func (c *Client) UploadFromReader(path string, content io.Reader, generateChecksum bool) error {
 	req := c.R().
-		SetHeader("Content-Type", "application/octet-stream")
+		SetHeader("Content-Type", "application/octet-stream").
+		SetBody(content)
 
 	if generateChecksum {
 		checksum := sha256.New()
-		content_slice, readErr := io.ReadAll(content)
-		if readErr != nil {
-			return readErr
-		}
-		_, err := checksum.Write(content_slice)
+		_, err := checksum.Write(content)
 		if err != nil {
 			return err
 		}
 		hex_checksum := hex.EncodeToString(checksum.Sum(nil))
-		req = req.SetHeader("Checksum", hex_checksum).SetBody(content_slice)
-	} else {
-		// Use Resty bufferless codepath if checksum is disabled
-		req = req.SetBody(content)
+		req = req.SetHeader("Checksum", hex_checksum)
 	}
 
 	resp, err := req.Put(path)


### PR DESCRIPTION
… reader instead of a []byte"

This reverts commit 06d145217a6af0a45d860ae14c050d70f96e0d2b.

Performs worse than passing a []byte buffer in JuiceFS objbench